### PR TITLE
fix for staticfiles deletion while removal

### DIFF
--- a/commands
+++ b/commands
@@ -85,6 +85,8 @@ case "$1" in
     _uuid=$(uuid)
 
     mkdir -m 777 -p "$HOME/data/$_uuid"
+    mkdir -m 777 -p "$HOME/data/$_uuid/staticfiles"
+    setfacl -dm u::rwx,g::rwx,o::rwx "$HOME/data/$_uuid/staticfiles"
 
     echo $HOME/data/$_uuid:$_container_path >> "$HOME/volumes_$APP"
 

--- a/plugin.toml
+++ b/plugin.toml
@@ -1,0 +1,4 @@
+[plugin]
+description = "dokku volume service plugin"
+version = "1.0.0"
+[plugin.config]


### PR DESCRIPTION
this is done so as to have this plugin be compatible with 0.4.x . However, this plugin doesn't fully work with dokku 0.4.x . The commands have been changed so as to allow deletion of staticfiles while removal of the persistent of volume via dokku.
